### PR TITLE
Change stylesheet_link_tag to proper javascript_include_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ E.g.:
         <%= yield %>
     <% end %>
 
-    <%= stylesheet_link_tag *webpack_asset_paths('application', extension:  'js') %>
+    <%= javascript_include_tag *webpack_asset_paths("application", extension: 'js') %>
 </body>
 ```
 


### PR DESCRIPTION
The code snippet in the README uses `stylesheet_link_tag` for the inclusion of the javascripts.